### PR TITLE
issue/hot.accept callback fires two times: changing fs.watch to node-…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const watch = require('node-watch');
 const Module = require('module');
 const isBuiltinModule = require('is-builtin-module');
 
@@ -55,7 +55,7 @@ function enableModuleReplacement(opts) {
     if (watching[path]) {
       return;
     }
-    watching[path] = fs.watch(path, { persistent: false }, function(
+    watching[path] = watch(path, { persistent: false }, function(
       eventType,
       filename
     ) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "touch": "^1.0.0"
   },
   "dependencies": {
-    "is-builtin-module": "^1.0.0"
+    "is-builtin-module": "^1.0.0",
+    "node-watch": "^0.5.8"
   }
 }


### PR DESCRIPTION
Fix for the issue : [hot.accept callback fires two times](https://github.com/sidorares/hot-module-replacement/issues/2) 
I replaced the fs.watch to the node-watch package, after many test with my coworker [ghoullier](https://github.com/ghoullier) who discussed the issue, it fix the "2-saves problem" reported on VsCode or VIM.