### PR TITLE
Fix undefined module bug with Next.js 

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function enableModuleReplacement(opts) {
     watching[path] = watch(path, { persistent: false }, function(eventType, filename) {
       const oldModule = require.cache[path];
 
-      const deps = collectDependencies(oldModule);
+      const deps = oldModule ? collectDependencies(oldModule) : [];
       const reloaded = {};
 
       for (let d = 0; d < deps.length; ++d) {


### PR DESCRIPTION
From #13, this simply returns `[]` when collecting dependencies for a module that doesn't exist in `require.cache`:

```
.../node_modules/hot-module-replacement/index.js:26
      const requiredMe = parents[root.filename]
                                      ^

TypeError: Cannot read property 'filename' of undefined
    at pathsToAcceptingModules (/Users/eric/Projects/ericclemmons/polydev/node_modules/hot-module-replacement/index.js:26:39)
    at collectDependencies (/Users/eric/Projects/ericclemmons/polydev/node_modules/hot-module-replacement/index.js:46:5)
    at Watcher.<anonymous> (/Users/eric/Projects/ericclemmons/polydev/node_modules/hot-module-replacement/index.js:77:20)
    at Watcher.emit (events.js:182:13)
    at callback (/Users/eric/Projects/ericclemmons/polydev/node_modules/node-watch/lib/watch.js:254:14)
    at /Users/eric/Projects/ericclemmons/polydev/node_modules/node-watch/lib/watch.js:112:10
    at Array.forEach (<anonymous>)
    at Timeout.handle [as _onTimeout] (/Users/eric/Projects/ericclemmons/polydev/node_modules/node-watch/lib/watch.js:107:24)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```