### PR TITLE
README.md: initialization must be at the beginning of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module tries to mimic [webpack HMR](https://webpack.js.org/api/hot-module-r
 
 ## Usage
 
-Put this code somewhere in your code to initialise hot reload
+Put this code at the beginning of your file to initialise hot reload
 
 ```js
 require('hot-module-replacement')({


### PR DESCRIPTION
Looks like hot-module-replacement initialization must be before any other imports in order to work.
It can take a while to figure it out, so I though it would be good to point that out in the readme.